### PR TITLE
We are not croaking when the plugin fails.

### DIFF
--- a/lib/Music/Tag.pm
+++ b/lib/Music/Tag.pm
@@ -146,7 +146,7 @@ sub add_plugin {
                         $plugin = 'Music::Tag::' . $plugin;
                     }
                     if ( $self->_has_module($plugin) ) {
-                        $ref = $plugin->new( $self, $options );
+                        $ref = $plugin->new( $self, $options ) or die;
                     }
                     return 1;
                 }


### PR DESCRIPTION
I think the croaks that follow do the right thing, but they're not getting the information they need.

$ perl -MMusic::Tag -E 'Music::Tag->new(shift) and say "why are we here?"' foo.mp7
Music::Tag::Auto Sorry, I can't find a plugin for /home/tim/foo.mp7 at /home/tim/perl5/perlbrew/perls/perl-5.12.4/lib/site_perl/5.12.4/Music/Tag.pm line 146
why are we here?
