### PR TITLE
Add missing =encoding rules for UTF-8 POD contents

### DIFF
--- a/lib/Music/Tag.pm
+++ b/lib/Music/Tag.pm
@@ -1096,6 +1096,8 @@ sub DESTROY {
 __END__
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 Music::Tag - Interface for collecting information about music files.

--- a/lib/Music/Tag/Auto.pm
+++ b/lib/Music/Tag/Auto.pm
@@ -63,6 +63,8 @@ sub new {
 __END__
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 Music::Tag::Auto - Plugin module for Music::Tag to load other plugins by file extension.

--- a/lib/Music/Tag/Generic.pm
+++ b/lib/Music/Tag/Generic.pm
@@ -239,6 +239,8 @@ sub DESTROY {
 __END__
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 Music::Tag::Generic - Parent Class for Music::Tag objects

--- a/lib/Music/Tag/Option.pm
+++ b/lib/Music/Tag/Option.pm
@@ -30,6 +30,8 @@ sub get_tag { goto &set_tag; }
 __END__
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 Music::Tag::Option - Plugin module for Music::Tag to set tags via tag optons 

--- a/lib/Music/Tag/Test.pm
+++ b/lib/Music/Tag/Test.pm
@@ -234,6 +234,8 @@ __END__
 
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 Music::Tag::Test - Routines to test Music::Tag plugins


### PR DESCRIPTION
On Perl 5.18.2, the POD tests fail because of the Copyright symbols.
