### PR TITLE
Add BUILD_REQUIRES for Test::Weaken

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,11 @@ WriteMakefile(
     AUTHOR        => 'Edward Allen (ealleniii _at_ cpan _dot_ org)',
     EXE_FILES     => ['bin/musictag'],
     LICENSE       => 'perl',
+    $ExtUtils::MakeMaker::VERSION >= 6.5503 ? (
+      BUILD_REQUIRES => {
+          'Test::Weaken' => 0,
+      }
+    ) : (),
     PREREQ_PM     => {
         'Config::Options' => 0.07,
         'Data::Dumper'    => 2.0,


### PR DESCRIPTION
Tests fail without it, and EU::MM 6.5503+ allows build requirements to
be specified.
